### PR TITLE
Update to ensure the latest VMware tools is downloaded based on the available version

### DIFF
--- a/scripts/Install-VMWareTools.ps1
+++ b/scripts/Install-VMWareTools.ps1
@@ -7,7 +7,11 @@ if([int]$wmi_operatingsystem.version.Substring(0,1) -le 6) { # Server 2008
     $url = 'https://packages.vmware.com/tools/releases/10.2.5/windows/x64/VMware-tools-10.2.5-8068406-x86_64.exe'
 } else { # Anything above 2008
     Write-Verbose "Latest Tools selected (not 2008R2)"
-    $url = 'https://packages.vmware.com/tools/releases/latest/windows/x64/VMware-tools-11.1.0-16036546-x86_64.exe'
+
+    $content = Invoke-WebRequest -Uri "https://packages.vmware.com/tools/releases/latest/windows/x64/"
+    $version = ($content.Links | Where-Object {$_.href -like "VMware-tools*" }).href
+
+    $url = "https://packages.vmware.com/tools/releases/latest/windows/x64/$($version)"
 }
 
 # install vmware tools

--- a/scripts/Install-VMWareTools.ps1
+++ b/scripts/Install-VMWareTools.ps1
@@ -21,7 +21,7 @@ $timeout = 30 # Timeout in minutes for it to fail this job
 $wc = New-Object System.Net.WebClient
 $wc.DownloadFile($url,$path)
 $args = '/s /v /qn reboot=r'
-Write-Verbose "Tools download successful.  Install starting."
+Write-Verbose "Tools download successful. Install starting."
 $timer = [Diagnostics.Stopwatch]::StartNew()
 Start-Process -FilePath $path -ArgumentList $args -PassThru
 
@@ -41,7 +41,7 @@ $toolswait = $true
 While ($toolswait){
     if(!(Test-VMInstall)){
         if($timer.Elaspsed.TotalMinutes -gt $timeout) {
-            Write-Verbose "Tools not detected within timeout.  Failing job."
+            Write-Verbose "Tools not detected within timeout. Failing job."
             Exit 1
         }
         Write-Verbose "Tools not detected yet."


### PR DESCRIPTION
The current script has a hardcoded version, which is not available in the latest URL. This will result in an error as the setup executable cannot be downloaded. By using the href the latest available version is selected. 

Please note, as there only one setup file available when browsing: https://packages.vmware.com/tools/releases/latest/windows/x64/.

The script will assume there is only a single result in the where-object statement. It would be better to add more logic to ensure this is validated.